### PR TITLE
corrige forma de fazer as buscas

### DIFF
--- a/src/pages/MainLayout/search/index.jsx
+++ b/src/pages/MainLayout/search/index.jsx
@@ -1,70 +1,54 @@
-import { useEffect, useState } from 'react';
-import { collection, query, where, getDocs } from 'firebase/firestore';
-import { db } from "../../../../firebase.config.js";
-import *as Tag from './index.js'
-import { ResultTable } from './componentes/table/index.jsx';
-import { Typography } from '@mui/material';
-import { FolderList } from './componentes/recipesresults.jsx';
+import { useEffect, useState } from 'react'
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  onSnapshot,
+} from 'firebase/firestore'
+import { db } from '../../../../firebase.config.js'
+import * as Tag from './index.js'
+import { ResultTable } from './componentes/table/index.jsx'
+import { Typography } from '@mui/material'
+import { FolderList } from './componentes/recipesresults.jsx'
+import { api_recipes } from '../../../api/recipes/recipes.js'
+import { api_users } from '../../../api/users/users.js'
+
+const recipeRef = collection(db, 'recipes')
+const userRef = collection(db, 'users')
+
 export const MySearch = ({ searchInput }) => {
-    const [results, setResults] = useState([]);
+  const [recipes, setRecipes] = useState([])
+  const [users, setUsers] = useState([])
 
-    async function searchInFirebase() {
+  const getData = async () => {
+    const recipes = await api_recipes.recipe.get()
+    const users = await api_users.user.get()
+    setRecipes(recipes)
+    setUsers(users)
+  }
+  useEffect(() => {
+    getData()
+  }, [])
+  const filteredRecipes =
+    recipes.filter((r) =>
+      r?.recipeTitle?.toLowerCase().includes(searchInput.toLowerCase())
+    ) || []
+  const filteredUsers =
+    users.filter((u) =>
+      u?.name.toLowerCase().includes(searchInput.toLowerCase())
+    ) || []
 
-        try {
-            const recipeRef = collection(db, 'recipes');
-            const userRef = collection(db, 'users');
-            const recipeSnapshot = await getDocs(query(recipeRef, where('recipeTitle', '>=', searchInput)));
-            const userSnapshot = await getDocs(query(userRef, where('name', '>=', searchInput)));
-
-            const tempResults = [];
-
-            recipeSnapshot.forEach((doc) => {
-                tempResults.push({ id: doc.id, ...doc.data(), type: 'recipe' });
-            });
-
-            userSnapshot.forEach((doc) => {
-                tempResults.push({ id: doc.id, ...doc.data(), type: 'user' });
-            });
-
-            return tempResults;
-        } catch (error) {
-            console.error('Erro ao realizar a busca:', error);
-            return [];
-        }
-    }
-
-    useEffect(() => {
-        async function fetchResults() {
-            if (searchInput) {
-                const results = await searchInFirebase();
-                setResults(results);
-                console.log(results);
-            } else {
-                setResults([]);
-            }
-        }
-
-        fetchResults();
-    }, [searchInput]);
-    const recipeResults = results.filter((result) => result.type === 'recipe');
-    const userResults = results.filter((result) => result.type === 'user');
-    return (
-        <Tag.MenuItemsLinks>
-            {results.length === 0 ? (
-                <p>Nenhum resultado encontrado.</p>
-            ) : (
-                <>
-                    <FolderList
-                        results={results}
-                        searchInput={searchInput}
-                    />
-                    <ResultTable
-                        results={results}
-                        searchInput={searchInput}
-                    />
-                </>
-            )
-            }
-        </Tag.MenuItemsLinks >
-    );
-};
+  return (
+    <Tag.MenuItemsLinks>
+      {filteredRecipes.length === 0 ? (
+        <p>Nenhum resultado encontrado.</p>
+      ) : (
+        <>
+          <FolderList results={filteredRecipes} searchInput={searchInput} />
+          <ResultTable results={filteredUsers} searchInput={searchInput} />
+        </>
+      )}
+    </Tag.MenuItemsLinks>
+  )
+}


### PR DESCRIPTION
Como o firebase não possui forma de buscar se algum campo inclui uma string de busca, tivemos que fazer a listagem de todas as receitas e usuários, para depois filtrar localmente no front.